### PR TITLE
Allow URL-encoded spaces in generated HTML

### DIFF
--- a/org-brain-export.el
+++ b/org-brain-export.el
@@ -205,14 +205,16 @@ the current entry in `org-brain-visualize-mind-map' mode."
     (with-temp-file org-brain-export-html-file
       (insert
        (apply #'format
-              (xmlgen
-               `(html
-                 (head)
-                 (body
-                  ,@(mapcar #'org-brain-export--generate-html data-rep))))
+              (string-replace
+               "%20" "%%20"
+               (xmlgen
+                `(html
+                  (head)
+                  (body
+                   ,@(mapcar #'org-brain-export--generate-html data-rep)))))
               (mapcar (lambda (x)
                         (or (ignore-errors (org-export-string-as (alist-get :text x) 'html t))
-                            "<i>Error during parsing of entry text...</i>"))
+                            "<p><i>Error during parsing of entry text...</i></p>"))
                       data-rep)))))
   (message "HTML export finished!"))
 


### PR DESCRIPTION
After generating the HTML with xmlgen, the HTML is passed to `format` as a
format string. However, “%” is not an uncommon character in HTML, most commonly
with “%20” for URL-encoded spaces. `format` would complain when it encountered
these.

This is a workaround to specifically get `format` to ignore `%20`. A more
general solution would be better, but this fixes my immediate issue of entries
having spaces in their names.

This also wraps the “Error during parsing of entry text” message in a `<p>`.